### PR TITLE
Fail-fast backend config access

### DIFF
--- a/src/main/scala/org/fs/mael/MaelstromDownloaderMain.scala
+++ b/src/main/scala/org/fs/mael/MaelstromDownloaderMain.scala
@@ -52,7 +52,7 @@ object MaelstromDownloaderMain extends App with Logging {
       val transferMgr = new SimpleTransferManager
       initBackends(backendMgr, transferMgr, globalCfg, eventMgr)
       val downloadListMgr = {
-        val serializer = new DownloadListSerializerImpl
+        val serializer = new DownloadListSerializerImpl(backendMgr)
         new DownloadListManager(serializer, downloadListFile, eventMgr)
       }
       downloadListMgr.load()

--- a/src/main/scala/org/fs/mael/MaelstromDownloaderMain.scala
+++ b/src/main/scala/org/fs/mael/MaelstromDownloaderMain.scala
@@ -6,8 +6,7 @@ import org.eclipse.swt.widgets.Display
 import org.eclipse.swt.widgets.Shell
 import org.fs.mael.backend.http.HttpBackend
 import org.fs.mael.core.backend.BackendManager
-import org.fs.mael.core.config.ConfigStore
-import org.fs.mael.core.config.FileBackedConfigStore
+import org.fs.mael.core.config.GlobalConfigStore
 import org.fs.mael.core.event.EventManager
 import org.fs.mael.core.event.EventManagerImpl
 import org.fs.mael.core.list.DownloadListManager
@@ -41,7 +40,7 @@ object MaelstromDownloaderMain extends App with Logging {
     val shell: Shell = StopWatch.measureAndCall {
       preloadClasses()
       // TODO: Show minimal splash screen
-      val globalCfg = new FileBackedConfigStore(globalCfgFile)
+      val globalCfg = new GlobalConfigStore(globalCfgFile)
       val migrationMgr = new MigrationManager(globalCfg, downloadListFile)
       migrationMgr.apply()
       val display = new Display()
@@ -85,7 +84,7 @@ object MaelstromDownloaderMain extends App with Logging {
   def initBackends(
     backendMgr:  BackendManager,
     transferMgr: TransferManager,
-    globalCfg:   ConfigStore,
+    globalCfg:   GlobalConfigStore,
     eventMgr:    EventManager
   ): Unit = {
     backendMgr += (new HttpBackend(transferMgr, globalCfg, eventMgr), 0)
@@ -94,7 +93,7 @@ object MaelstromDownloaderMain extends App with Logging {
   def initUi(
     display:         Display,
     resources:       Resources,
-    globalCfg:       ConfigStore,
+    globalCfg:       GlobalConfigStore,
     backendMgr:      BackendManager,
     downloadListMgr: DownloadListManager,
     eventMgr:        EventManager

--- a/src/main/scala/org/fs/mael/backend/http/HttpBackend.scala
+++ b/src/main/scala/org/fs/mael/backend/http/HttpBackend.scala
@@ -41,6 +41,8 @@ class HttpBackend(
 
   override def pageDescriptors = HttpSettings.Local.pageDescriptors
 
+  override def settingsAccessChecker = HttpBackend.SettingsAccessChecker
+
   /**
    * Parse a textual HTTP request, yielding a downloa1dable entry
    */
@@ -103,8 +105,6 @@ class HttpBackend(
     de.backendSpecificCfg.set(HttpSettings.Cookies, cookies)
     de
   }
-
-  def settingsAccessChecker: SettingsAccessChecker = HttpBackend.SettingsAccessChecker
 }
 
 object HttpBackend {

--- a/src/main/scala/org/fs/mael/backend/http/HttpBackend.scala
+++ b/src/main/scala/org/fs/mael/backend/http/HttpBackend.scala
@@ -9,7 +9,7 @@ import scala.collection.immutable.ListMap
 import org.fs.mael.backend.http.config.HttpSettings
 import org.fs.mael.backend.http.utils.HttpUtils
 import org.fs.mael.core.backend.AbstractBackend
-import org.fs.mael.core.config.ConfigStore
+import org.fs.mael.core.config.IGlobalConfigStore
 import org.fs.mael.core.entry.DownloadEntry
 import org.fs.mael.core.event.EventManager
 import org.fs.mael.core.transfer.TransferManager
@@ -17,7 +17,7 @@ import org.fs.mael.core.utils.CoreUtils._
 
 class HttpBackend(
   transferMgr:            TransferManager,
-  override val globalCfg: ConfigStore,
+  override val globalCfg: IGlobalConfigStore,
   eventMgr:               EventManager
 ) extends AbstractBackend {
   override val id: String = HttpBackend.Id

--- a/src/main/scala/org/fs/mael/backend/http/HttpBackend.scala
+++ b/src/main/scala/org/fs/mael/backend/http/HttpBackend.scala
@@ -9,7 +9,9 @@ import scala.collection.immutable.ListMap
 import org.fs.mael.backend.http.config.HttpSettings
 import org.fs.mael.backend.http.utils.HttpUtils
 import org.fs.mael.core.backend.AbstractBackend
+import org.fs.mael.core.config.DefaultSettingsAccessChecker
 import org.fs.mael.core.config.IGlobalConfigStore
+import org.fs.mael.core.config.SettingsAccessChecker
 import org.fs.mael.core.entry.DownloadEntry
 import org.fs.mael.core.event.EventManager
 import org.fs.mael.core.transfer.TransferManager
@@ -101,10 +103,14 @@ class HttpBackend(
     de.backendSpecificCfg.set(HttpSettings.Cookies, cookies)
     de
   }
+
+  def settingsAccessChecker: SettingsAccessChecker = HttpBackend.SettingsAccessChecker
 }
 
 object HttpBackend {
   val Id = "http"
+
+  val SettingsAccessChecker: SettingsAccessChecker = new DefaultSettingsAccessChecker(Id)
 
   private val RequestPattern = "GET ([^\\s]+) HTTP/[\\d.]+".r
 

--- a/src/main/scala/org/fs/mael/backend/http/HttpDownloader.scala
+++ b/src/main/scala/org/fs/mael/backend/http/HttpDownloader.scala
@@ -244,7 +244,7 @@ class HttpDownloader(
     }
 
     private def addCustomHeaders(rb: RequestBuilder, cookieStore: CookieStore): Unit = {
-      import config.HttpSettings._
+      import org.fs.mael.backend.http.config.HttpSettings._
       val localCfg = de.backendSpecificCfg
       val userAgentOption = localCfg(UserAgent)
       userAgentOption foreach { userAgent =>

--- a/src/main/scala/org/fs/mael/core/backend/AbstractBackend.scala
+++ b/src/main/scala/org/fs/mael/core/backend/AbstractBackend.scala
@@ -21,7 +21,7 @@ abstract class AbstractBackend extends Backend {
 
   /** Initialize default config for a new entry */
   protected def defaultCfg: BackendConfigStore = {
-    new BackendConfigStore(globalCfg, id)
+    BackendConfigStore(globalCfg, settingsAccessChecker)
   }
 
   override def create(
@@ -37,6 +37,7 @@ abstract class AbstractBackend extends Backend {
   }
 
   override def layoutConfig(cfgOption: Option[BackendConfigStore], tabFolder: TabFolder, isEditable: Boolean): BackendConfigUi = {
-    new BackendConfigUiImpl(id, isEditable, cfgOption, globalCfg, tabFolder, pageDescriptors)
+    val resultCfg = BackendConfigStore(settingsAccessChecker)
+    new BackendConfigUiImpl(resultCfg, isEditable, cfgOption, globalCfg, tabFolder, pageDescriptors)
   }
 }

--- a/src/main/scala/org/fs/mael/core/backend/AbstractBackend.scala
+++ b/src/main/scala/org/fs/mael/core/backend/AbstractBackend.scala
@@ -7,8 +7,8 @@ import org.eclipse.swt.widgets.TabFolder
 import org.fs.mael.core.backend.ui.BackendConfigUi
 import org.fs.mael.core.backend.ui.BackendConfigUiImpl
 import org.fs.mael.core.checksum.Checksum
-import org.fs.mael.core.config.ConfigStore
-import org.fs.mael.core.config.InMemoryConfigStore
+import org.fs.mael.core.config.BackendConfigStore
+import org.fs.mael.core.config.IGlobalConfigStore
 import org.fs.mael.core.entry.DownloadEntry
 import org.fs.mael.ui.config.MFieldEditorPreferencePage
 import org.fs.mael.ui.config.MPreferencePageDescriptor
@@ -17,11 +17,11 @@ abstract class AbstractBackend extends Backend {
   protected def pageDescriptors: Seq[MPreferencePageDescriptor[_ <: MFieldEditorPreferencePage]]
 
   /** Global application config, its subpath serves as template for download-specific configs */
-  protected def globalCfg: ConfigStore
+  protected def globalCfg: IGlobalConfigStore
 
   /** Initialize default config for a new entry */
-  protected def defaultCfg: InMemoryConfigStore = {
-    new InMemoryConfigStore(globalCfg, id)
+  protected def defaultCfg: BackendConfigStore = {
+    new BackendConfigStore(globalCfg, id)
   }
 
   override def create(
@@ -30,13 +30,13 @@ abstract class AbstractBackend extends Backend {
     filenameOption: Option[String],
     checksumOption: Option[Checksum],
     comment:        String,
-    cfgOption:      Option[InMemoryConfigStore]
+    cfgOption:      Option[BackendConfigStore]
   ): DownloadEntry = {
     require(isSupported(uri), "URI not supported")
     DownloadEntry(id, uri, location, filenameOption, checksumOption, comment, cfgOption getOrElse defaultCfg)
   }
 
-  override def layoutConfig(cfgOption: Option[InMemoryConfigStore], tabFolder: TabFolder, isEditable: Boolean): BackendConfigUi = {
+  override def layoutConfig(cfgOption: Option[BackendConfigStore], tabFolder: TabFolder, isEditable: Boolean): BackendConfigUi = {
     new BackendConfigUiImpl(id, isEditable, cfgOption, globalCfg, tabFolder, pageDescriptors)
   }
 }

--- a/src/main/scala/org/fs/mael/core/backend/Backend.scala
+++ b/src/main/scala/org/fs/mael/core/backend/Backend.scala
@@ -7,6 +7,7 @@ import org.eclipse.swt.widgets.TabFolder
 import org.fs.mael.core.backend.ui.BackendConfigUi
 import org.fs.mael.core.checksum.Checksum
 import org.fs.mael.core.config.BackendConfigStore
+import org.fs.mael.core.config.SettingsAccessChecker
 import org.fs.mael.core.entry.DownloadEntry
 
 trait Backend {
@@ -28,6 +29,8 @@ trait Backend {
   ): DownloadEntry
 
   def downloader: BackendDownloader
+
+  def settingsAccessChecker: SettingsAccessChecker
 
   def layoutConfig(cfgOption: Option[BackendConfigStore], tabFolder: TabFolder, isEditable: Boolean): BackendConfigUi
 }

--- a/src/main/scala/org/fs/mael/core/backend/Backend.scala
+++ b/src/main/scala/org/fs/mael/core/backend/Backend.scala
@@ -6,7 +6,7 @@ import java.net.URI
 import org.eclipse.swt.widgets.TabFolder
 import org.fs.mael.core.backend.ui.BackendConfigUi
 import org.fs.mael.core.checksum.Checksum
-import org.fs.mael.core.config.InMemoryConfigStore
+import org.fs.mael.core.config.BackendConfigStore
 import org.fs.mael.core.entry.DownloadEntry
 
 trait Backend {
@@ -24,10 +24,10 @@ trait Backend {
     filenameOption: Option[String],
     checksumOption: Option[Checksum],
     comment:        String,
-    cfgOption:      Option[InMemoryConfigStore]
+    cfgOption:      Option[BackendConfigStore]
   ): DownloadEntry
 
   def downloader: BackendDownloader
 
-  def layoutConfig(cfgOption: Option[InMemoryConfigStore], tabFolder: TabFolder, isEditable: Boolean): BackendConfigUi
+  def layoutConfig(cfgOption: Option[BackendConfigStore], tabFolder: TabFolder, isEditable: Boolean): BackendConfigUi
 }

--- a/src/main/scala/org/fs/mael/core/backend/ui/AbstractBackendConfigUi.scala
+++ b/src/main/scala/org/fs/mael/core/backend/ui/AbstractBackendConfigUi.scala
@@ -1,8 +1,8 @@
 package org.fs.mael.core.backend.ui
 
 import org.eclipse.swt.widgets.TabFolder
-import org.fs.mael.core.config.ConfigStore
-import org.fs.mael.core.config.InMemoryConfigStore
+import org.fs.mael.core.config.BackendConfigStore
+import org.fs.mael.core.config.IGlobalConfigStore
 import org.fs.mael.core.utils.CoreUtils._
 import org.fs.mael.ui.config.MFieldEditorPreferencePage
 import org.fs.mael.ui.config.MPreferencePageDescriptor
@@ -12,15 +12,15 @@ abstract class AbstractBackendConfigUi extends BackendConfigUi {
 
   def isEditable: Boolean
 
-  def cfgOption: Option[ConfigStore]
+  def cfgOption: Option[BackendConfigStore]
 
-  def globalCfg: ConfigStore
+  def globalCfg: IGlobalConfigStore
 
   def tabFolder: TabFolder
 
   def pageDescriptions: Seq[MPreferencePageDescriptor[_ <: MFieldEditorPreferencePage]]
 
-  val cfg = new InMemoryConfigStore
+  val cfg = new BackendConfigStore
 
   val pages: Seq[MFieldEditorPreferencePage] = {
     cfgOption match {
@@ -32,7 +32,7 @@ abstract class AbstractBackendConfigUi extends BackendConfigUi {
     }
   }
 
-  override def get(): InMemoryConfigStore = {
+  override def get(): BackendConfigStore = {
     if (isEditable) {
       requireFriendly(pages.forall(_.performOk), "Some settings are invalid")
     }

--- a/src/main/scala/org/fs/mael/core/backend/ui/AbstractBackendConfigUi.scala
+++ b/src/main/scala/org/fs/mael/core/backend/ui/AbstractBackendConfigUi.scala
@@ -8,8 +8,6 @@ import org.fs.mael.ui.config.MFieldEditorPreferencePage
 import org.fs.mael.ui.config.MPreferencePageDescriptor
 
 abstract class AbstractBackendConfigUi extends BackendConfigUi {
-  def backendId: String
-
   def isEditable: Boolean
 
   def cfgOption: Option[BackendConfigStore]
@@ -20,12 +18,13 @@ abstract class AbstractBackendConfigUi extends BackendConfigUi {
 
   def pageDescriptions: Seq[MPreferencePageDescriptor[_ <: MFieldEditorPreferencePage]]
 
-  val cfg = new BackendConfigStore(backendId)
+  /** Resulting config, should initially be empty */
+  def resultCfg: BackendConfigStore
 
   val pages: Seq[MFieldEditorPreferencePage] = {
     cfgOption match {
-      case Some(_cfg) => cfg.resetTo(_cfg) // Ignore default preferences
-      case None       => cfg.resetTo(globalCfg)
+      case Some(cfg) => resultCfg.resetTo(cfg) // Ignore default preferences
+      case None      => resultCfg.resetTo(globalCfg)
     }
     pageDescriptions map { pageDescr =>
       createPage(pageDescr, tabFolder)
@@ -36,7 +35,7 @@ abstract class AbstractBackendConfigUi extends BackendConfigUi {
     if (isEditable) {
       requireFriendly(pages.forall(_.performOk), "Some settings are invalid")
     }
-    cfg
+    resultCfg
   }
 
   protected def createPage[T <: MFieldEditorPreferencePage](pageDescr: MPreferencePageDescriptor[T], tabFolder: TabFolder): T

--- a/src/main/scala/org/fs/mael/core/backend/ui/AbstractBackendConfigUi.scala
+++ b/src/main/scala/org/fs/mael/core/backend/ui/AbstractBackendConfigUi.scala
@@ -20,12 +20,12 @@ abstract class AbstractBackendConfigUi extends BackendConfigUi {
 
   def pageDescriptions: Seq[MPreferencePageDescriptor[_ <: MFieldEditorPreferencePage]]
 
-  val cfg = new BackendConfigStore
+  val cfg = new BackendConfigStore(backendId)
 
   val pages: Seq[MFieldEditorPreferencePage] = {
     cfgOption match {
-      case Some(_cfg) => cfg.resetTo(_cfg, backendId) // Ignore default preferences
-      case None       => cfg.resetTo(globalCfg, backendId)
+      case Some(_cfg) => cfg.resetTo(_cfg) // Ignore default preferences
+      case None       => cfg.resetTo(globalCfg)
     }
     pageDescriptions map { pageDescr =>
       createPage(pageDescr, tabFolder)

--- a/src/main/scala/org/fs/mael/core/backend/ui/BackendConfigUi.scala
+++ b/src/main/scala/org/fs/mael/core/backend/ui/BackendConfigUi.scala
@@ -1,7 +1,7 @@
 package org.fs.mael.core.backend.ui
 
-import org.fs.mael.core.config.InMemoryConfigStore
+import org.fs.mael.core.config.BackendConfigStore
 
 trait BackendConfigUi {
-  def get(): InMemoryConfigStore
+  def get(): BackendConfigStore
 }

--- a/src/main/scala/org/fs/mael/core/backend/ui/BackendConfigUiImpl.scala
+++ b/src/main/scala/org/fs/mael/core/backend/ui/BackendConfigUiImpl.scala
@@ -8,12 +8,13 @@ import org.eclipse.swt.widgets.TabFolder
 import org.eclipse.swt.widgets.TabItem
 import org.fs.mael.core.config.BackendConfigStore
 import org.fs.mael.core.config.IGlobalConfigStore
+import org.fs.mael.core.config.SettingsAccessChecker
 import org.fs.mael.ui.config.MFieldEditorPreferencePage
 import org.fs.mael.ui.config.MPreferencePageDescriptor
 import org.fs.mael.ui.utils.SwtUtils
 
 class BackendConfigUiImpl(
-  override val backendId:        String,
+  override val resultCfg:        BackendConfigStore,
   override val isEditable:       Boolean,
   override val cfgOption:        Option[BackendConfigStore],
   override val globalCfg:        IGlobalConfigStore,
@@ -29,7 +30,7 @@ class BackendConfigUiImpl(
     tab.setControl(container)
 
     val page = pageDescr.clazz.newInstance()
-    page.setConfigStore(cfg)
+    page.setConfigStore(resultCfg.innerStore)
     page.noDefaultAndApplyButton()
     page.createControl(container)
     page.getControl.setLayoutData(new GridData(GridData.FILL, GridData.FILL, true, true))

--- a/src/main/scala/org/fs/mael/core/backend/ui/BackendConfigUiImpl.scala
+++ b/src/main/scala/org/fs/mael/core/backend/ui/BackendConfigUiImpl.scala
@@ -6,7 +6,8 @@ import org.eclipse.swt.layout.GridLayout
 import org.eclipse.swt.widgets.Composite
 import org.eclipse.swt.widgets.TabFolder
 import org.eclipse.swt.widgets.TabItem
-import org.fs.mael.core.config.ConfigStore
+import org.fs.mael.core.config.BackendConfigStore
+import org.fs.mael.core.config.IGlobalConfigStore
 import org.fs.mael.ui.config.MFieldEditorPreferencePage
 import org.fs.mael.ui.config.MPreferencePageDescriptor
 import org.fs.mael.ui.utils.SwtUtils
@@ -14,8 +15,8 @@ import org.fs.mael.ui.utils.SwtUtils
 class BackendConfigUiImpl(
   override val backendId:        String,
   override val isEditable:       Boolean,
-  override val cfgOption:        Option[ConfigStore],
-  override val globalCfg:        ConfigStore,
+  override val cfgOption:        Option[BackendConfigStore],
+  override val globalCfg:        IGlobalConfigStore,
   override val tabFolder:        TabFolder,
   override val pageDescriptions: Seq[MPreferencePageDescriptor[_ <: MFieldEditorPreferencePage]]
 ) extends AbstractBackendConfigUi {

--- a/src/main/scala/org/fs/mael/core/backend/ui/BackendConfigUiImpl.scala
+++ b/src/main/scala/org/fs/mael/core/backend/ui/BackendConfigUiImpl.scala
@@ -30,7 +30,7 @@ class BackendConfigUiImpl(
     tab.setControl(container)
 
     val page = pageDescr.clazz.newInstance()
-    page.setConfigStore(resultCfg.innerStore)
+    page.setConfigStore(resultCfg)
     page.noDefaultAndApplyButton()
     page.createControl(container)
     page.getControl.setLayoutData(new GridData(GridData.FILL, GridData.FILL, true, true))

--- a/src/main/scala/org/fs/mael/core/config/BackendConfigStore.scala
+++ b/src/main/scala/org/fs/mael/core/config/BackendConfigStore.scala
@@ -1,0 +1,33 @@
+package org.fs.mael.core.config
+
+import org.slf4s.Logging
+
+class BackendConfigStore extends InMemoryConfigStore with Logging {
+  def this(globalCfg: IGlobalConfigStore, pathPrefix: String) = {
+    this()
+    resetTo(globalCfg, pathPrefix)
+  }
+
+  def this(serialString: String) = {
+    this()
+    InMemoryConfigStore.applyTo(this, serialString)(log)
+  }
+
+  override def resetTo(that: ConfigStore): Unit = {
+    super.resetTo(that)
+    that match {
+      case that: IGlobalConfigStore =>
+        ??? // FIXME: Destroy global-linked properties
+      case _ => // NOOP
+    }
+  }
+
+  override def resetTo(that: ConfigStore, pathPrefix: String): Unit = {
+    super.resetTo(that, pathPrefix)
+    that match {
+      case that: IGlobalConfigStore =>
+        ??? // FIXME: Destroy global-linked properties
+      case _ => // NOOP
+    }
+  }
+}

--- a/src/main/scala/org/fs/mael/core/config/BackendConfigStore.scala
+++ b/src/main/scala/org/fs/mael/core/config/BackendConfigStore.scala
@@ -12,7 +12,7 @@ import org.slf4s.Logging
  * Serves as a "guarding proxy" for {@code InMemoryConfigStore}
  */
 case class BackendConfigStore protected (
-  val innerStore: InMemoryConfigStore,
+  protected val innerStore: InMemoryConfigStore,
   accessChecker:  SettingsAccessChecker
 ) extends IConfigStore with Logging {
 

--- a/src/main/scala/org/fs/mael/core/config/BackendConfigStore.scala
+++ b/src/main/scala/org/fs/mael/core/config/BackendConfigStore.scala
@@ -1,14 +1,24 @@
 package org.fs.mael.core.config
 
-import org.slf4s.Logging
-import org.eclipse.jface.preference.PreferenceStore
+import java.io.ByteArrayInputStream
 
-class BackendConfigStore(
+import scala.io.Codec
+
+import org.eclipse.jface.preference.PreferenceStore
+import org.fs.utility.Imports._
+import org.slf4s.Logging
+
+/**
+ * Serves as a "guarding proxy" for {@code InMemoryConfigStore}
+ */
+case class BackendConfigStore protected (
   val innerStore: InMemoryConfigStore,
-  accessChecker: SettingsAccessChecker
+  accessChecker:  SettingsAccessChecker
 ) extends IConfigStore with Logging {
 
   protected var allowedSettingsOption: Option[Seq[ConfigSetting[_]]] = None
+
+  val backendId = accessChecker.backendId
 
   override def settings: Set[ConfigSetting[_]] = innerStore.settings
 
@@ -36,7 +46,91 @@ class BackendConfigStore(
     innerStore.addSettingChangedListener(setting)(f)
   }
 
+  def toSerialForm: (String, String) = {
+    (backendId, innerStore.toSerialString)
+  }
+
+  /** Reset to the state of given config, taking only accessible entries */
+  def resetTo(that: IConfigStore): Unit = {
+    val diff = computeDiff(that)
+    resetStoreWithoutEvents(that)
+    this.innerStore.settings = that.settings.filter(accessChecker.isSettingAccessible)
+
+    // Remove excessive keys
+    val keys = that.inner.preferenceNames()
+    this.innerStore.listerensEnabled = false
+    keys filterNot (accessChecker.isSettingIdAccessible) foreach (this.innerStore.inner.setToDefault)
+    this.innerStore.listerensEnabled = true
+
+    (diff).foreach {
+      case (k, oldV, newV) => inner.firePropertyChangeEvent(k, oldV, newV)
+    }
+  }
+
+  private def resetStoreWithoutEvents(that: IConfigStore): Unit = {
+    // Clear existing properties before loading
+    this.innerStore.inner.preferenceNames foreach (this.inner.setToDefault)
+    val bais = new ByteArrayInputStream(that.toByteArray)
+    this.innerStore.inner.load(bais)
+    this.innerStore.settings = that.settings
+  }
+
+  private def computeDiff(that: IConfigStore): Seq[(String, Any, Any)] = {
+    // Type capture helpers
+    def get[T](setting: ConfigSetting[T], store: PreferenceStore): Any =
+      setting.toRepr(setting.get(store))
+    def getDefault[T](setting: ConfigSetting[T]): Any =
+      setting.toRepr(setting.default)
+
+    val oldSettings = this.settings
+    val newSettings = that.settings filter (accessChecker.isSettingAccessible)
+    val removed: Seq[(String, Any, Any)] = (oldSettings diff newSettings).toSeq map { setting =>
+      (setting.id, get(setting, this.inner), getDefault(setting))
+    }
+    val changed: Seq[(String, Any, Any)] = (oldSettings intersect newSettings).toSeq map { setting =>
+      (setting.id, get(setting, this.inner), get(setting, that.inner))
+    }
+    val added: Seq[(String, Any, Any)] = (newSettings diff oldSettings).toSeq map { setting =>
+      (setting.id, getDefault(setting), get(setting, that.inner))
+    }
+    removed ++ changed ++ added
+  }
+
   protected def ensureSettingAccess(setting: ConfigSetting[_]): Unit = {
-    require(accessChecker.isSettingAccessible(setting), s"Setting $setting is outside the scope!")
+    require(accessChecker.isSettingIdAccessible(setting.id), s"Setting $setting is outside the scope!")
+  }
+}
+
+object BackendConfigStore extends Logging {
+  def apply(
+    accessChecker: SettingsAccessChecker
+  ): BackendConfigStore = {
+    new BackendConfigStore(new InMemoryConfigStore, accessChecker)
+  }
+
+  def apply(
+    baseStore:     IConfigStore,
+    accessChecker: SettingsAccessChecker
+  ): BackendConfigStore = {
+    val result = this(accessChecker)
+    result.resetTo(baseStore)
+    result
+  }
+
+  def apply(
+    serialString:  String,
+    accessChecker: SettingsAccessChecker
+  ): BackendConfigStore = {
+    val baseStore = new InMemoryConfigStore
+    // Charset is taken from java.util.Properties.store
+    val bytes = serialString.getBytes(Codec.ISO8859.charSet)
+    baseStore.inner.load(new ByteArrayInputStream(bytes))
+    val keys = baseStore.inner.preferenceNames()
+    baseStore.settings = keys.toSeq.map { key =>
+      val lookup = ConfigSetting.lookup(key)
+      if (lookup.isEmpty) log.warn("No config setting for property key " + key)
+      lookup
+    }.yieldDefined.toSet
+    this(baseStore, accessChecker)
   }
 }

--- a/src/main/scala/org/fs/mael/core/config/ConfigStore.scala
+++ b/src/main/scala/org/fs/mael/core/config/ConfigStore.scala
@@ -9,7 +9,7 @@ import org.eclipse.jface.preference.PreferenceStore
 import org.eclipse.jface.util.PropertyChangeEvent
 
 trait ConfigStore extends IConfigStore {
-  protected[config] var settings: Set[ConfigSetting[_]] = Set.empty
+  var settings: Set[ConfigSetting[_]] = Set.empty
   protected[config] var listerensEnabled: Boolean = true
 
   override val inner: PreferenceStore

--- a/src/main/scala/org/fs/mael/core/config/ConfigStore.scala
+++ b/src/main/scala/org/fs/mael/core/config/ConfigStore.scala
@@ -8,13 +8,11 @@ import org.eclipse.jface.preference.IPreferenceStore
 import org.eclipse.jface.preference.PreferenceStore
 import org.eclipse.jface.util.PropertyChangeEvent
 
-trait ConfigStore {
+trait ConfigStore extends IConfigStore {
   protected[config] var settings: Set[ConfigSetting[_]] = Set.empty
   protected[config] var listerensEnabled: Boolean = true
 
-  val inner: PreferenceStore
-
-  def save(): Unit
+  override val inner: PreferenceStore
 
   /**
    * Initialize default values for the given config setting.
@@ -48,20 +46,6 @@ trait ConfigStore {
       val e2 = ConfigChangedEvent[T](setting.fromRepr(e.getOldValue.asInstanceOf[setting.Repr]), setting.fromRepr(e.getNewValue.asInstanceOf[setting.Repr]))
       f(e2)
     }
-  }
-
-  private def toByteArrayOutputStream: ByteArrayOutputStream = {
-    val baos = new ByteArrayOutputStream
-    inner.save(baos, null)
-    baos
-  }
-
-  /**
-   * Serializes the store content of this manager into byte array.
-   * Note that due to presence of comment with current date/time, its content will differ between invocations!
-   */
-  protected[config] def toByteArray: Array[Byte] = {
-    toByteArrayOutputStream.toByteArray()
   }
 
   def toSerialString: String = {

--- a/src/main/scala/org/fs/mael/core/config/DefaultSettingsAccessChecker.scala
+++ b/src/main/scala/org/fs/mael/core/config/DefaultSettingsAccessChecker.scala
@@ -1,0 +1,7 @@
+package org.fs.mael.core.config
+
+case class DefaultSettingsAccessChecker(override val backendId: String) extends SettingsAccessChecker {
+  override def isSettingIdAccessible(settingId: String): Boolean = {
+    settingId startsWith (backendId + ".")
+  }
+}

--- a/src/main/scala/org/fs/mael/core/config/FileBackedConfigStore.scala
+++ b/src/main/scala/org/fs/mael/core/config/FileBackedConfigStore.scala
@@ -7,7 +7,7 @@ import org.eclipse.jface.preference.PreferenceStore
 import org.fs.mael.core.utils.CoreUtils._
 
 class FileBackedConfigStore(val file: File) extends ConfigStore {
-  override val inner = new PreferenceStore().withCode { store =>
+  override lazy val inner = new PreferenceStore().withCode { store =>
     file.getParentFile.mkdirs()
     store.setFilename(file.getAbsolutePath)
     try {

--- a/src/main/scala/org/fs/mael/core/config/GlobalConfigStore.scala
+++ b/src/main/scala/org/fs/mael/core/config/GlobalConfigStore.scala
@@ -1,0 +1,9 @@
+package org.fs.mael.core.config
+
+import java.io.File
+
+class GlobalConfigStore(file: File)
+  extends FileBackedConfigStore(file)
+  with IGlobalConfigStore {
+
+}

--- a/src/main/scala/org/fs/mael/core/config/IConfigStore.scala
+++ b/src/main/scala/org/fs/mael/core/config/IConfigStore.scala
@@ -1,0 +1,34 @@
+package org.fs.mael.core.config
+
+import org.eclipse.jface.preference.PreferenceStore
+import java.io.ByteArrayOutputStream
+
+trait IConfigStore {
+  def settings: Set[ConfigSetting[_]]
+
+  def inner: PreferenceStore
+
+  def save(): Unit
+
+  def initDefault(setting: ConfigSetting[_]): Unit
+
+  def apply[T](setting: ConfigSetting[T]): T
+
+  def set[T](setting: ConfigSetting[T], value: T): Unit
+
+  def addSettingChangedListener[T](setting: ConfigSetting[T])(f: ConfigChangedEvent[T] => Unit): Unit
+
+  protected def toByteArrayOutputStream: ByteArrayOutputStream = {
+    val baos = new ByteArrayOutputStream
+    inner.save(baos, null)
+    baos
+  }
+
+  /**
+   * Serializes the store content of this manager into byte array.
+   * Note that due to presence of comment with current date/time, its content will differ between invocations!
+   */
+  def toByteArray: Array[Byte] = {
+    toByteArrayOutputStream.toByteArray()
+  }
+}

--- a/src/main/scala/org/fs/mael/core/config/IGlobalConfigStore.scala
+++ b/src/main/scala/org/fs/mael/core/config/IGlobalConfigStore.scala
@@ -1,0 +1,4 @@
+package org.fs.mael.core.config
+
+/** Used to separate GlobalConfigStore users from implementation details */
+trait IGlobalConfigStore extends ConfigStore

--- a/src/main/scala/org/fs/mael/core/config/InMemoryConfigStore.scala
+++ b/src/main/scala/org/fs/mael/core/config/InMemoryConfigStore.scala
@@ -1,93 +1,10 @@
 package org.fs.mael.core.config
 
-import java.io.ByteArrayInputStream
-
-import scala.io.Codec
-
 import org.eclipse.jface.preference.PreferenceStore
-import org.fs.utility.Imports._
 import org.slf4s.Logging
 
 class InMemoryConfigStore extends ConfigStore with Logging {
   override val inner = new PreferenceStore()
-
-  def this(that: ConfigStore) = {
-    this()
-    resetTo(that)
-  }
-
-  def this(that: ConfigStore, pathPrefix: String) = {
-    this()
-    resetTo(that, pathPrefix)
-  }
-
-  def this(serialString: String) = {
-    this()
-    // Charset is taken from java.util.Properties.store
-    val bytes = serialString.getBytes(Codec.ISO8859.charSet)
-    inner.load(new ByteArrayInputStream(bytes))
-    val keys = this.inner.preferenceNames()
-    this.settings = keys.toSeq.map { key =>
-      val lookup = ConfigSetting.lookup(key)
-      if (lookup.isEmpty) log.warn("No config setting for property key " + key)
-      lookup
-    }.yieldDefined.toSet
-  }
-
-  /** Reset state to mirror the given one */
-  def resetTo(that: ConfigStore): Unit = {
-    val diff = computeDiff(that, "")
-    resetStoreWithoutEvents(that)
-    (diff).foreach {
-      case (k, oldV, newV) => inner.firePropertyChangeEvent(k, oldV, newV)
-    }
-  }
-
-  /** Reset to the state of given config, taking only entries starting with {@code pathPrefix} */
-  def resetTo(that: IConfigStore, pathPrefix: String): Unit = {
-    val diff = computeDiff(that, pathPrefix + ".")
-    resetStoreWithoutEvents(that)
-    this.settings = that.settings.filter(_.id.startsWith(pathPrefix + "."))
-
-    // Remove excessive keys
-    val keys = that.inner.preferenceNames()
-    listerensEnabled = false
-    keys filter (!_.startsWith(pathPrefix + ".")) foreach (this.inner.setToDefault)
-    listerensEnabled = true
-
-    (diff).foreach {
-      case (k, oldV, newV) => inner.firePropertyChangeEvent(k, oldV, newV)
-    }
-  }
-
-  private def resetStoreWithoutEvents(that: IConfigStore): Unit = {
-    // Clear existing properties before loading
-    this.inner.preferenceNames foreach (this.inner.setToDefault)
-    val bais = new ByteArrayInputStream(that.toByteArray)
-    this.inner.load(bais)
-    this.settings = that.settings
-  }
-
-  private def computeDiff(that: IConfigStore, prefix: String): Seq[(String, Any, Any)] = {
-    // Type capture helpers
-    def get[T](setting: ConfigSetting[T], store: PreferenceStore): Any =
-      setting.toRepr(setting.get(store))
-    def getDefault[T](setting: ConfigSetting[T]): Any =
-      setting.toRepr(setting.default)
-
-    val oldSettings = this.settings
-    val newSettings = that.settings filter (_.id startsWith prefix)
-    val removed: Seq[(String, Any, Any)] = (oldSettings diff newSettings).toSeq map { setting =>
-      (setting.id, get(setting, this.inner), getDefault(setting))
-    }
-    val changed: Seq[(String, Any, Any)] = (oldSettings intersect newSettings).toSeq map { setting =>
-      (setting.id, get(setting, this.inner), get(setting, that.inner))
-    }
-    val added: Seq[(String, Any, Any)] = (newSettings diff oldSettings).toSeq map { setting =>
-      (setting.id, getDefault(setting), get(setting, that.inner))
-    }
-    removed ++ changed ++ added
-  }
 
   def save(): Unit = { /* NOOP */ }
 }

--- a/src/main/scala/org/fs/mael/core/config/SettingsAccessChecker.scala
+++ b/src/main/scala/org/fs/mael/core/config/SettingsAccessChecker.scala
@@ -1,0 +1,10 @@
+package org.fs.mael.core.config
+
+/**
+ * Used by BackendConfigStore to ensure out-of-scope settings are never queried.
+ *
+ * This is needed to ensure a fail-fast behaviour if some new setting was added partially.
+ */
+trait SettingsAccessChecker {
+  def isSettingAccessible(setting: ConfigSetting[_]): Boolean
+}

--- a/src/main/scala/org/fs/mael/core/config/SettingsAccessChecker.scala
+++ b/src/main/scala/org/fs/mael/core/config/SettingsAccessChecker.scala
@@ -6,5 +6,10 @@ package org.fs.mael.core.config
  * This is needed to ensure a fail-fast behaviour if some new setting was added partially.
  */
 trait SettingsAccessChecker {
-  def isSettingAccessible(setting: ConfigSetting[_]): Boolean
+  def backendId: String
+
+  def isSettingIdAccessible(settingId: String): Boolean
+
+  def isSettingAccessible(setting: ConfigSetting[_]): Boolean =
+    isSettingIdAccessible(setting.id)
 }

--- a/src/main/scala/org/fs/mael/core/entry/DownloadEntry.scala
+++ b/src/main/scala/org/fs/mael/core/entry/DownloadEntry.scala
@@ -11,9 +11,6 @@ import org.fs.mael.core.checksum.Checksum
 import org.fs.mael.core.config.BackendConfigStore
 
 import com.github.nscala_time.time.Imports._
-import org.fs.mael.core.config.SettingsAccessChecker
-import org.fs.mael.core.config.BackendConfigStore
-import org.fs.mael.core.config.InMemoryConfigStore
 
 /**
  * Entry for a specific download processor, implementation details may vary.

--- a/src/main/scala/org/fs/mael/core/entry/DownloadEntry.scala
+++ b/src/main/scala/org/fs/mael/core/entry/DownloadEntry.scala
@@ -23,15 +23,15 @@ import org.fs.mael.core.config.InMemoryConfigStore
  * @author FS
  */
 class DownloadEntry private (
-  override val id:                 UUID,
-  override val dateCreated:        DateTime,
-  val backendId:                   String,
-  var uri:                         URI,
-  var location:                    File,
-  var filenameOption:              Option[String],
-  var checksumOption:              Option[Checksum],
-  var comment:                     String,
-  private val _backendSpecificCfg: InMemoryConfigStore
+  override val id:          UUID,
+  override val dateCreated: DateTime,
+  val backendId:            String,
+  var uri:                  URI,
+  var location:             File,
+  var filenameOption:       Option[String],
+  var checksumOption:       Option[Checksum],
+  var comment:              String,
+  val backendSpecificCfg:   BackendConfigStore
 ) extends DownloadEntryView with DownloadEntryLoggableView {
 
   var status: Status = Status.Stopped
@@ -43,10 +43,6 @@ class DownloadEntry private (
   val sections: mutable.Map[Start, Downloaded] = mutable.Map.empty
 
   var downloadLog: IndexedSeq[LogEntry] = IndexedSeq.empty
-
-  def backendSpecificCfg(accessChecker: SettingsAccessChecker): BackendConfigStore = {
-    new BackendConfigStore(_backendSpecificCfg, accessChecker)
-  }
 
   override def addDownloadLogEntry(entry: LogEntry): Unit = {
     this.downloadLog = this.downloadLog :+ entry
@@ -63,7 +59,7 @@ object DownloadEntry {
     comment:            String,
     backendSpecificCfg: BackendConfigStore
   ) = {
-    new DownloadEntry(UUID.randomUUID(), DateTime.now(), backendId, uri, location, filenameOption, checksumOption, comment, backendSpecificCfg.innerStore)
+    new DownloadEntry(UUID.randomUUID(), DateTime.now(), backendId, uri, location, filenameOption, checksumOption, comment, backendSpecificCfg)
   }
 
   def load(
@@ -77,6 +73,6 @@ object DownloadEntry {
     comment:            String,
     backendSpecificCfg: BackendConfigStore
   ) = {
-    new DownloadEntry(id, dateCreated, backendId, uri, location, filenameOption, checksumOption, comment, backendSpecificCfg.innerStore)
+    new DownloadEntry(id, dateCreated, backendId, uri, location, filenameOption, checksumOption, comment, backendSpecificCfg)
   }
 }

--- a/src/main/scala/org/fs/mael/core/entry/DownloadEntry.scala
+++ b/src/main/scala/org/fs/mael/core/entry/DownloadEntry.scala
@@ -8,7 +8,7 @@ import scala.collection.mutable
 
 import org.fs.mael.core.Status
 import org.fs.mael.core.checksum.Checksum
-import org.fs.mael.core.config.InMemoryConfigStore
+import org.fs.mael.core.config.BackendConfigStore
 
 import com.github.nscala_time.time.Imports._
 
@@ -28,7 +28,7 @@ class DownloadEntry private (
   var filenameOption:       Option[String],
   var checksumOption:       Option[Checksum],
   var comment:              String,
-  val backendSpecificCfg:   InMemoryConfigStore
+  val backendSpecificCfg:   BackendConfigStore
 ) extends DownloadEntryView with DownloadEntryLoggableView {
 
   var status: Status = Status.Stopped
@@ -54,7 +54,7 @@ object DownloadEntry {
     filenameOption:     Option[String],
     checksumOption:     Option[Checksum],
     comment:            String,
-    backendSpecificCfg: InMemoryConfigStore
+    backendSpecificCfg: BackendConfigStore
   ) = {
     new DownloadEntry(UUID.randomUUID(), DateTime.now(), backendId, uri, location, filenameOption, checksumOption, comment, backendSpecificCfg)
   }
@@ -68,7 +68,7 @@ object DownloadEntry {
     filenameOption:     Option[String],
     checksumOption:     Option[Checksum],
     comment:            String,
-    backendSpecificCfg: InMemoryConfigStore
+    backendSpecificCfg: BackendConfigStore
   ) = {
     new DownloadEntry(id, dateCreated, backendId, uri, location, filenameOption, checksumOption, comment, backendSpecificCfg)
   }

--- a/src/main/scala/org/fs/mael/core/entry/DownloadEntryView.scala
+++ b/src/main/scala/org/fs/mael/core/entry/DownloadEntryView.scala
@@ -8,7 +8,7 @@ import scala.collection.MapLike
 
 import org.fs.mael.core.Status
 import org.fs.mael.core.checksum.Checksum
-import org.fs.mael.core.config.InMemoryConfigStore
+import org.fs.mael.core.config.BackendConfigStore
 
 import com.github.nscala_time.time.Imports._
 
@@ -74,7 +74,7 @@ trait DownloadEntryView {
 
   def downloadLog: IndexedSeq[LogEntry]
 
-  def backendSpecificCfg: InMemoryConfigStore
+  def backendSpecificCfg: BackendConfigStore
 
   override final def equals(obj: Any): Boolean = obj match {
     case dd: DownloadEntryView => this.id == dd.id

--- a/src/main/scala/org/fs/mael/core/list/DownloadListSerializerImpl.scala
+++ b/src/main/scala/org/fs/mael/core/list/DownloadListSerializerImpl.scala
@@ -96,6 +96,10 @@ object DownloadListSerializerImpl {
   class BackendConfigSerializer(backendMgr: BackendManager)
     extends CustomSerializer[BackendConfigStore](format => (
       {
+        case JString(s) if s matches "[a-zA-Z-]\\|" =>
+          val backendId = s.dropRight(1)
+          val accessChecker = backendMgr(backendId).settingsAccessChecker
+          BackendConfigStore(accessChecker)
         case JString(s) =>
           val (backendId, serialString) = {
             val split = s.split("\\|", 2)

--- a/src/main/scala/org/fs/mael/core/list/DownloadListSerializerImpl.scala
+++ b/src/main/scala/org/fs/mael/core/list/DownloadListSerializerImpl.scala
@@ -1,12 +1,11 @@
 package org.fs.mael.core.list
 
-import java.io.ByteArrayInputStream
-import java.io.ByteArrayOutputStream
 import java.io.File
 
 import org.fs.mael.core.Status
+import org.fs.mael.core.backend.BackendManager
 import org.fs.mael.core.checksum.ChecksumType
-import org.fs.mael.core.config.InMemoryConfigStore
+import org.fs.mael.core.config.BackendConfigStore
 import org.fs.mael.core.entry.DownloadEntry
 import org.fs.mael.core.entry.LogEntry
 import org.json4s._
@@ -15,7 +14,7 @@ import org.json4s.jackson.Serialization
 
 import com.github.nscala_time.time.Imports._
 
-class DownloadListSerializerImpl extends DownloadListSerializer {
+class DownloadListSerializerImpl(backendMgr: BackendManager) extends DownloadListSerializer {
 
   private implicit val formats = {
     val deSerializer = {
@@ -37,7 +36,7 @@ class DownloadListSerializerImpl extends DownloadListSerializer {
       FileSerializer,
       StatusSerializer,
       LogTypeSerializer,
-      BackendConfigSerializer,
+      new BackendConfigSerializer(backendMgr),
       new EnumSerializer[ChecksumType]
     )
     Serialization.formats(NoTypeHints) + deSerializer ++ serializers + SectionsKeySerializer ++ JavaTypesSerializers.all
@@ -94,16 +93,19 @@ object DownloadListSerializerImpl {
     }
   ))
 
-  object InMemoryConfigSerializer
-    extends CustomSerializer[InMemoryConfigStore](format => (
+  class BackendConfigSerializer(backendMgr: BackendManager)
+    extends CustomSerializer[BackendConfigStore](format => (
       {
-        case x: JString =>
-          new InMemoryConfigStore(x.s)
-        case JNothing =>
-          new InMemoryConfigStore()
+        case JString(s) =>
+          val (backendId, serialString) = {
+            val split = s.split("\\|", 2)
+            (split(0), split(1))
+          }
+          val accessChecker = backendMgr(backendId).settingsAccessChecker
+          BackendConfigStore(serialString, accessChecker)
       }, {
-        case cfg: InMemoryConfigStore =>
-          JString(cfg.toSerialString)
+        case cfg: BackendConfigStore =>
+          JString(cfg.toSerialForm.productIterator.mkString("|"))
       }
     ))
 

--- a/src/main/scala/org/fs/mael/core/list/DownloadListSerializerImpl.scala
+++ b/src/main/scala/org/fs/mael/core/list/DownloadListSerializerImpl.scala
@@ -6,7 +6,7 @@ import java.io.File
 
 import org.fs.mael.core.Status
 import org.fs.mael.core.checksum.ChecksumType
-import org.fs.mael.core.config.BackendConfigStore
+import org.fs.mael.core.config.InMemoryConfigStore
 import org.fs.mael.core.entry.DownloadEntry
 import org.fs.mael.core.entry.LogEntry
 import org.json4s._
@@ -94,15 +94,15 @@ object DownloadListSerializerImpl {
     }
   ))
 
-  object BackendConfigSerializer
-    extends CustomSerializer[BackendConfigStore](format => (
+  object InMemoryConfigSerializer
+    extends CustomSerializer[InMemoryConfigStore](format => (
       {
         case x: JString =>
-          new BackendConfigStore(x.s)
+          new InMemoryConfigStore(x.s)
         case JNothing =>
-          new BackendConfigStore()
+          new InMemoryConfigStore()
       }, {
-        case cfg: BackendConfigStore =>
+        case cfg: InMemoryConfigStore =>
           JString(cfg.toSerialString)
       }
     ))

--- a/src/main/scala/org/fs/mael/core/list/DownloadListSerializerImpl.scala
+++ b/src/main/scala/org/fs/mael/core/list/DownloadListSerializerImpl.scala
@@ -6,7 +6,7 @@ import java.io.File
 
 import org.fs.mael.core.Status
 import org.fs.mael.core.checksum.ChecksumType
-import org.fs.mael.core.config.InMemoryConfigStore
+import org.fs.mael.core.config.BackendConfigStore
 import org.fs.mael.core.entry.DownloadEntry
 import org.fs.mael.core.entry.LogEntry
 import org.json4s._
@@ -37,7 +37,7 @@ class DownloadListSerializerImpl extends DownloadListSerializer {
       FileSerializer,
       StatusSerializer,
       LogTypeSerializer,
-      InMemoryConfigSerializer,
+      BackendConfigSerializer,
       new EnumSerializer[ChecksumType]
     )
     Serialization.formats(NoTypeHints) + deSerializer ++ serializers + SectionsKeySerializer ++ JavaTypesSerializers.all
@@ -94,15 +94,15 @@ object DownloadListSerializerImpl {
     }
   ))
 
-  object InMemoryConfigSerializer
-    extends CustomSerializer[InMemoryConfigStore](format => (
+  object BackendConfigSerializer
+    extends CustomSerializer[BackendConfigStore](format => (
       {
         case x: JString =>
-          new InMemoryConfigStore(x.s)
+          new BackendConfigStore(x.s)
         case JNothing =>
-          new InMemoryConfigStore()
+          new BackendConfigStore()
       }, {
-        case cfg: InMemoryConfigStore =>
+        case cfg: BackendConfigStore =>
           JString(cfg.toSerialString)
       }
     ))

--- a/src/main/scala/org/fs/mael/core/migration/MigrationManager.scala
+++ b/src/main/scala/org/fs/mael/core/migration/MigrationManager.scala
@@ -6,11 +6,11 @@ import java.nio.file.Files
 import scala.io.Codec
 import scala.io.Source
 
-import org.fs.mael.core.config.ConfigStore
 import org.fs.mael.core.config.ConfigSetting
+import org.fs.mael.core.config.IGlobalConfigStore
 import org.slf4s.Logging
 
-class MigrationManager(globalCfg: ConfigStore, downloadListFile: File) extends Logging {
+class MigrationManager(globalCfg: IGlobalConfigStore, downloadListFile: File) extends Logging {
   import MigrationManager._
 
   // TODO: What if config didn't exist before? No migrations should be applied in that case!

--- a/src/main/scala/org/fs/mael/ui/EditDownloadDialog.scala
+++ b/src/main/scala/org/fs/mael/ui/EditDownloadDialog.scala
@@ -14,7 +14,6 @@ import org.eclipse.swt.graphics.Font
 import org.eclipse.swt.layout._
 import org.eclipse.swt.widgets._
 import org.fs.mael.backend.http.HttpBackend
-import org.fs.mael.backend.http.utils.HttpUtils
 import org.fs.mael.core.Status
 import org.fs.mael.core.backend.Backend
 import org.fs.mael.core.backend.BackendManager
@@ -22,8 +21,8 @@ import org.fs.mael.core.backend.ui.BackendConfigUi
 import org.fs.mael.core.checksum.Checksum
 import org.fs.mael.core.checksum.ChecksumType
 import org.fs.mael.core.checksum.Checksums
-import org.fs.mael.core.config.ConfigStore
-import org.fs.mael.core.config.InMemoryConfigStore
+import org.fs.mael.core.config.BackendConfigStore
+import org.fs.mael.core.config.IGlobalConfigStore
 import org.fs.mael.core.entry.DownloadEntry
 import org.fs.mael.core.event.EventManager
 import org.fs.mael.core.list.DownloadListManager
@@ -37,7 +36,7 @@ class EditDownloadDialog(
   _deOption:       Option[DownloadEntry],
   parent:          Shell,
   resources:       Resources,
-  globalCfg:       ConfigStore,
+  globalCfg:       IGlobalConfigStore,
   backendMgr:      BackendManager,
   downloadListMgr: DownloadListManager,
   eventMgr:        EventManager
@@ -341,7 +340,7 @@ class EditDownloadDialog(
     filenameOption: Option[String],
     checksumOption: Option[Checksum],
     comment:        String
-  )(deCfgOption: Option[InMemoryConfigStore]): Unit = {
+  )(deCfgOption: Option[BackendConfigStore]): Unit = {
     val de = backend.create(uri, location, filenameOption, checksumOption, comment, deCfgOption)
     downloadListMgr.add(de)
     processAutostart(backend, de)
@@ -355,7 +354,7 @@ class EditDownloadDialog(
     filenameOption: Option[String],
     checksumOption: Option[Checksum],
     comment:        String
-  )(deCfgOption: Option[InMemoryConfigStore]): Unit = {
+  )(deCfgOption: Option[BackendConfigStore]): Unit = {
     val newFilenameOption = filenameOption orElse de.filenameOption
     if (location != de.location || filenameOption != de.filenameOption) {
       if (de.downloadedSize > 0) {

--- a/src/main/scala/org/fs/mael/ui/MainFrame.scala
+++ b/src/main/scala/org/fs/mael/ui/MainFrame.scala
@@ -19,7 +19,7 @@ import org.eclipse.swt.widgets._
 import org.fs.mael.BuildInfo
 import org.fs.mael.core.Status
 import org.fs.mael.core.backend.BackendManager
-import org.fs.mael.core.config.ConfigStore
+import org.fs.mael.core.config.IGlobalConfigStore
 import org.fs.mael.core.entry.DownloadEntry
 import org.fs.mael.core.event.EventForUi
 import org.fs.mael.core.event.EventManager
@@ -39,7 +39,7 @@ import org.slf4s.Logging
 class MainFrame(
   display:         Display,
   resources:       Resources,
-  globalCfg:       ConfigStore,
+  globalCfg:       IGlobalConfigStore,
   backendMgr:      BackendManager,
   downloadListMgr: DownloadListManager,
   eventMgr:        EventManager

--- a/src/main/scala/org/fs/mael/ui/components/DownloadsTable.scala
+++ b/src/main/scala/org/fs/mael/ui/components/DownloadsTable.scala
@@ -8,7 +8,7 @@ import org.eclipse.swt.widgets.Listener
 import org.eclipse.swt.widgets.Table
 import org.eclipse.swt.widgets.TableColumn
 import org.eclipse.swt.widgets.TableItem
-import org.fs.mael.core.config.ConfigStore
+import org.fs.mael.core.config.IGlobalConfigStore
 import org.fs.mael.core.entry.DownloadEntry
 import org.fs.mael.core.speed.SpeedTracker
 import org.fs.mael.core.utils.CoreUtils._
@@ -22,7 +22,7 @@ import com.github.nscala_time.time.Imports._
 class DownloadsTable(
   parent:    Composite,
   resources: Resources,
-  globalCfg: ConfigStore
+  globalCfg: IGlobalConfigStore
 ) extends MUiComponent[Table](parent) {
 
   // TODO: Save/restore column widths

--- a/src/main/scala/org/fs/mael/ui/config/GlobalSettingsController.scala
+++ b/src/main/scala/org/fs/mael/ui/config/GlobalSettingsController.scala
@@ -6,10 +6,10 @@ import org.eclipse.jface.preference.PreferenceDialog
 import org.eclipse.jface.preference.PreferenceManager
 import org.eclipse.swt.widgets.Shell
 import org.fs.mael.backend.http.config.HttpSettings
-import org.fs.mael.core.config.ConfigStore
+import org.fs.mael.core.config.IGlobalConfigStore
 import org.fs.mael.core.utils.CoreUtils._
 
-class GlobalSettingsController(val globalCfg: ConfigStore) {
+class GlobalSettingsController(val globalCfg: IGlobalConfigStore) {
 
   val mgr = new PreferenceManager().withCode { mgr =>
     def addPage(pageDescr: MPreferencePageDescriptor[_ <: MFieldEditorPreferencePage]): Unit = {

--- a/src/main/scala/org/fs/mael/ui/config/MFieldEditorPreferencePage.scala
+++ b/src/main/scala/org/fs/mael/ui/config/MFieldEditorPreferencePage.scala
@@ -6,7 +6,7 @@ import org.eclipse.jface.preference.IPreferenceStore
 import org.eclipse.jface.preference.RadioGroupFieldEditor
 import org.eclipse.swt.widgets.Composite
 import org.fs.mael.core.config.ConfigSetting
-import org.fs.mael.core.config.ConfigStore
+import org.fs.mael.core.config.IConfigStore
 
 abstract class MFieldEditorPreferencePage(style: Int) extends FieldEditorPreferencePage(style) {
   /** Making this method visible */
@@ -17,7 +17,7 @@ abstract class MFieldEditorPreferencePage(style: Int) extends FieldEditorPrefere
    * Please use this if an element is added manually rather than through helpers defined here
    */
   protected var _fieldEditorsWithParents: IndexedSeq[(FieldEditor, Composite)] = IndexedSeq.empty
-  protected var _cfg: ConfigStore = _
+  protected var _cfg: IConfigStore = _
 
   /**
    * Initialize a default value for the given config setting.
@@ -28,7 +28,7 @@ abstract class MFieldEditorPreferencePage(style: Int) extends FieldEditorPrefere
     _cfg.initDefault(setting)
   }
 
-  def setConfigStore(cfg: ConfigStore): Unit = {
+  def setConfigStore(cfg: IConfigStore): Unit = {
     _cfg = cfg
     super.setPreferenceStore(cfg.inner)
   }

--- a/src/test/scala/org/fs/mael/backend/http/HttpBackendSpec.scala
+++ b/src/test/scala/org/fs/mael/backend/http/HttpBackendSpec.scala
@@ -6,6 +6,7 @@ import java.net.URI
 import scala.collection.immutable.ListMap
 
 import org.fs.mael.backend.http.config.HttpSettings
+import org.fs.mael.core.config.IGlobalConfigStore
 import org.fs.mael.core.config.InMemoryConfigStore
 import org.fs.mael.core.transfer.SimpleTransferManager
 import org.fs.mael.test.stub.StoringEventManager
@@ -16,7 +17,7 @@ import org.scalatest.FunSuite
 class HttpBackendSpec
   extends FunSuite {
 
-  val backend = new HttpBackend(new SimpleTransferManager, new InMemoryConfigStore, new StoringEventManager)
+  val backend = new HttpBackend(new SimpleTransferManager, new InMemoryConfigStore with IGlobalConfigStore, new StoringEventManager)
 
   test("supported URLs") {
     assert(backend.isSupported(new URI("http://abcde")))

--- a/src/test/scala/org/fs/mael/backend/http/HttpDownloaderSpec.scala
+++ b/src/test/scala/org/fs/mael/backend/http/HttpDownloaderSpec.scala
@@ -466,7 +466,7 @@ class HttpDownloaderSpec
       filenameOption     = Some(filename),
       checksumOption     = None,
       comment            = "my comment",
-      backendSpecificCfg = new BackendConfigStore
+      backendSpecificCfg = BackendConfigStore(HttpBackend.SettingsAccessChecker)
     )
   }
 

--- a/src/test/scala/org/fs/mael/backend/http/HttpDownloaderSpec.scala
+++ b/src/test/scala/org/fs/mael/backend/http/HttpDownloaderSpec.scala
@@ -15,7 +15,7 @@ import org.apache.http.entity._
 import org.fs.mael.core.Status
 import org.fs.mael.core.checksum.Checksum
 import org.fs.mael.core.checksum.ChecksumType
-import org.fs.mael.core.config.InMemoryConfigStore
+import org.fs.mael.core.config.BackendConfigStore
 import org.fs.mael.core.entry.DownloadEntry
 import org.fs.mael.core.event.Events
 import org.fs.mael.core.event.PriorityEvent
@@ -466,7 +466,7 @@ class HttpDownloaderSpec
       filenameOption     = Some(filename),
       checksumOption     = None,
       comment            = "my comment",
-      backendSpecificCfg = new InMemoryConfigStore
+      backendSpecificCfg = new BackendConfigStore
     )
   }
 

--- a/src/test/scala/org/fs/mael/core/config/BackendConfigStoreSpec.scala
+++ b/src/test/scala/org/fs/mael/core/config/BackendConfigStoreSpec.scala
@@ -1,0 +1,179 @@
+package org.fs.mael.core.config
+
+import org.fs.mael.test.TestUtils
+import org.junit.runner.RunWith
+import org.scalatest.BeforeAndAfter
+import org.scalatest.FunSuite
+
+import junit.framework.AssertionFailedError
+
+@RunWith(classOf[org.scalatest.junit.JUnitRunner])
+class BackendConfigStoreSpec
+  extends FunSuite
+  with BeforeAndAfter {
+
+  private val setting11 = ConfigSetting("group1.1", "my-default11")
+  private val setting12 = ConfigSetting("group1.2", -1)
+  private val setting21 = ConfigSetting("group2.1", Radio.r1, Radio.values)
+  private val setting22 = ConfigSetting("group2.2", Some("my-default22"))
+
+  sealed abstract class Radio(idx: Int) extends ConfigSetting.RadioValue(idx.toString, idx + "-pretty")
+  object Radio {
+    object r1 extends Radio(1)
+    object r2 extends Radio(2)
+    object r3 extends Radio(3)
+    val values = Seq(r1, r2, r3)
+  }
+
+  private var failureOption: Option[Throwable] = None
+
+  before {
+    failureOption = None
+  }
+
+  test("access, modification, equality and hash code") {
+    val store1 = BackendConfigStore(TestUtils.DummySettingsAccessChecker)
+    val store2 = BackendConfigStore(TestUtils.DummySettingsAccessChecker)
+    assert(store1 === store2)
+    assert(store1.hashCode === store2.hashCode)
+
+    // Setting property to its default value
+    store2.set(setting11, setting11.default)
+    assert(store1 === store2)
+    assert(store1.hashCode === store2.hashCode)
+
+    // store1 is modified
+    store1.set(setting11, "my-new11")
+    store1.set(setting12, 100500)
+    store1.set(setting21, Radio.r2)
+    store1.set(setting22, Some("my-new22"))
+    assert(store1 !== store2)
+    assert(store1.hashCode !== store2.hashCode)
+
+    // store2 is modified accordingly
+    store2.set(setting12, 100500)
+    store2.set(setting22, Some("my-new22"))
+    store2.set(setting21, Radio.r2)
+    store2.set(setting11, "my-new11")
+    assert(store1 === store2)
+    assert(store1.hashCode === store2.hashCode)
+  }
+
+  test("access restrictions") {
+    val store1 = BackendConfigStore(new DefaultSettingsAccessChecker("group1"))
+    val store2 = BackendConfigStore(new DefaultSettingsAccessChecker("group1"))
+    assert(store1 === store2)
+
+    // Modifying allowed settings
+    assert(store1(setting11) === "my-default11")
+    assert(store1(setting12) === -1)
+    store1.set(setting11, "my-new11")
+    store1.set(setting12, 100500)
+    assert(store1(setting11) === "my-new11")
+    assert(store1(setting12) === 100500)
+    assert(store1 !== store2)
+    assert(store1.hashCode !== store2.hashCode)
+
+    // Trying to access disallowed settings
+    intercept[IllegalArgumentException] {
+      store1.set(setting21, Radio.r2)
+    }
+    intercept[IllegalArgumentException] {
+      store1(setting22)
+    }
+    intercept[IllegalArgumentException] {
+      store1.addSettingChangedListener(setting21)(expectPropertyNotChanged)
+    }
+  }
+
+  test("reset (unconditional)") {
+    val store1 = BackendConfigStore(TestUtils.DummySettingsAccessChecker)
+    val store2 = BackendConfigStore(TestUtils.DummySettingsAccessChecker)
+    store1.resetTo(store1)
+    assert(store1 === store2)
+
+    store2.set(setting11, "my-new11")
+    store2.set(setting21, Radio.r2)
+    store2.set(setting22, None)
+
+    store1.resetTo(store2)
+    assert(store1 === store2)
+    assert(store1(setting11) === "my-new11")
+    assert(store1(setting12) === setting12.default)
+    assert(store1(setting21) === Radio.r2)
+    assert(store1(setting22) === None)
+  }
+
+  test("reset (unconditional) - listener notification") {
+    val store1 = BackendConfigStore(TestUtils.DummySettingsAccessChecker)
+    val store2 = BackendConfigStore(TestUtils.DummySettingsAccessChecker)
+    var (triggered11, triggered12, triggered21, triggered22) = (0, 0, 0, 0)
+    store1.addSettingChangedListener(setting11)(expectPropertyChange(setting11.default, "my-new11", triggered11 != 0, triggered11 += 1))
+    store1.addSettingChangedListener(setting12)(expectPropertyNotChanged)
+    store1.addSettingChangedListener(setting21)(expectPropertyNotChanged)
+    store1.addSettingChangedListener(setting22)(expectPropertyChange(setting22.default, None, triggered22 != 0, triggered22 += 1))
+
+    store2.set(setting11, "my-new11")
+    store2.set(setting22, None)
+
+    store1.resetTo(store2)
+    failureOption foreach (th => fail(th))
+    assert(triggered11 === 1)
+    assert(triggered12 === 0)
+    assert(triggered21 === 0)
+    assert(triggered22 === 1)
+  }
+
+  test("reset (conditional)") {
+    val store11 = BackendConfigStore(new DefaultSettingsAccessChecker("group1"))
+    val store2 = BackendConfigStore(TestUtils.DummySettingsAccessChecker)
+    assert(store11 !== store2)
+
+    store2.set(setting11, "my-new11")
+    store2.set(setting12, 100500)
+    store2.set(setting21, Radio.r2)
+
+    store11.resetTo(store2)
+    assert(store11(setting11) === "my-new11")
+    assert(store11(setting12) === 100500)
+
+    val store12 = BackendConfigStore(new DefaultSettingsAccessChecker("group2"))
+    store12.resetTo(store2)
+    assert(store12(setting21) === Radio.r2)
+  }
+
+  test("reset (conditional) - listener notification") {
+    val store1 = BackendConfigStore(new DefaultSettingsAccessChecker("group2"))
+    val store2 = BackendConfigStore(TestUtils.DummySettingsAccessChecker)
+    var (triggered21, triggered22) = (0, 0)
+    store1.addSettingChangedListener(setting21)(expectPropertyChange(setting21.default, Radio.r2, triggered21 != 0, triggered21 += 1))
+    store1.addSettingChangedListener(setting22)(expectPropertyChange(setting22.default, Some("my-new22"), triggered22 != 0, triggered22 += 1))
+
+    store2.set(setting11, "my-new11")
+    store2.set(setting12, 100500)
+    store2.set(setting21, Radio.r2)
+    store2.set(setting22, Some("my-new22"))
+
+    store1.resetTo(store2)
+    failureOption foreach (th => fail(th))
+    assert(triggered21 === 1)
+    assert(triggered22 === 1)
+  }
+
+  private def expectPropertyChange[T](from: T, to: T, isTriggered: => Boolean, setTriggered: => Unit) = { (e: ConfigChangedEvent[T]) =>
+    try {
+      assert(!isTriggered)
+      setTriggered
+      assert(e.oldValue === from)
+      assert(e.newValue === to)
+    } catch {
+      case th: Throwable => failureOption = Some(th)
+    }
+    ()
+  }
+
+  private def expectPropertyNotChanged = (e: ConfigChangedEvent[_]) => {
+    failureOption = Some(new AssertionFailedError("This listener should not be notified"))
+    ()
+  }
+}

--- a/src/test/scala/org/fs/mael/core/list/DownloadListManagerSpec.scala
+++ b/src/test/scala/org/fs/mael/core/list/DownloadListManagerSpec.scala
@@ -10,7 +10,7 @@ import scala.io.Source
 import org.fs.mael.core.Status
 import org.fs.mael.core.checksum.Checksum
 import org.fs.mael.core.checksum.ChecksumType
-import org.fs.mael.core.config.InMemoryConfigStore
+import org.fs.mael.core.config.BackendConfigStore
 import org.fs.mael.core.entry.DownloadEntry
 import org.fs.mael.core.event.Events._
 import org.fs.mael.core.utils.CoreUtils._
@@ -120,8 +120,8 @@ class DownloadListManagerSpec
     assert(eventMgr.events(5) === Removed(entries(1)))
   }
 
-  private def defaultCfg: InMemoryConfigStore = {
-    val cfg = new InMemoryConfigStore
+  private def defaultCfg: BackendConfigStore = {
+    val cfg = new BackendConfigStore
     cfg.initDefault(StubBackend.StubSetting)
     cfg
   }

--- a/src/test/scala/org/fs/mael/core/list/DownloadListManagerSpec.scala
+++ b/src/test/scala/org/fs/mael/core/list/DownloadListManagerSpec.scala
@@ -121,7 +121,7 @@ class DownloadListManagerSpec
   }
 
   private def defaultCfg: BackendConfigStore = {
-    val cfg = new BackendConfigStore
+    val cfg = BackendConfigStore(StubBackend.SettingsAccessChecker)
     cfg.initDefault(StubBackend.StubSetting)
     cfg
   }

--- a/src/test/scala/org/fs/mael/core/list/DownloadListSerializerImplSpec.scala
+++ b/src/test/scala/org/fs/mael/core/list/DownloadListSerializerImplSpec.scala
@@ -8,6 +8,7 @@ import org.fs.mael.core.Status
 import org.fs.mael.core.backend.BackendManager
 import org.fs.mael.core.checksum.Checksum
 import org.fs.mael.core.checksum.ChecksumType
+import org.fs.mael.core.config.IGlobalConfigStore
 import org.fs.mael.core.config.InMemoryConfigStore
 import org.fs.mael.core.entry.DownloadEntry
 import org.fs.mael.core.entry.LogEntry
@@ -30,7 +31,7 @@ class DownloadListSerializerImplSpec
 
   private val backendMgr = (new BackendManager).withCode { backendMgr =>
     backendMgr += (new StubBackend, Int.MinValue)
-    backendMgr += (new HttpBackend(new SimpleTransferManager, new InMemoryConfigStore, eventMgr), 0)
+    backendMgr += (new HttpBackend(new SimpleTransferManager, new InMemoryConfigStore with IGlobalConfigStore, eventMgr), 0)
   }
 
   private val serializer = new DownloadListSerializerImpl()

--- a/src/test/scala/org/fs/mael/core/list/DownloadListSerializerImplSpec.scala
+++ b/src/test/scala/org/fs/mael/core/list/DownloadListSerializerImplSpec.scala
@@ -34,7 +34,7 @@ class DownloadListSerializerImplSpec
     backendMgr += (new HttpBackend(new SimpleTransferManager, new InMemoryConfigStore with IGlobalConfigStore, eventMgr), 0)
   }
 
-  private val serializer = new DownloadListSerializerImpl()
+  private val serializer = new DownloadListSerializerImpl(backendMgr)
 
   test("stub - simple") {
     assertSingularSerializationWorks(createDE("simple")())

--- a/src/test/scala/org/fs/mael/core/migration/MigrationManagerSpec.scala
+++ b/src/test/scala/org/fs/mael/core/migration/MigrationManagerSpec.scala
@@ -20,13 +20,13 @@ class MigrationManagerSpec
 
   import MigrationManager._
 
-  val cfg = new InMemoryConfigStore with IGlobalConfigStore
+  var cfg = new InMemoryConfigStore with IGlobalConfigStore
   val file = File.createTempFile("temp", ".tmp")
 
   val mgr = new MigrationManager(cfg, file)
 
   after {
-    cfg.reset()
+    cfg = new InMemoryConfigStore with IGlobalConfigStore
     Files.write(file.toPath(), Array.emptyByteArray)
   }
 

--- a/src/test/scala/org/fs/mael/core/migration/MigrationManagerSpec.scala
+++ b/src/test/scala/org/fs/mael/core/migration/MigrationManagerSpec.scala
@@ -6,6 +6,7 @@ import java.nio.file.Files
 import scala.io.Codec
 import scala.io.Source
 
+import org.fs.mael.core.config.IGlobalConfigStore
 import org.fs.mael.core.config.InMemoryConfigStore
 import org.fs.mael.test.TestUtils._
 import org.junit.runner.RunWith
@@ -19,7 +20,7 @@ class MigrationManagerSpec
 
   import MigrationManager._
 
-  val cfg = new InMemoryConfigStore
+  val cfg = new InMemoryConfigStore with IGlobalConfigStore
   val file = File.createTempFile("temp", ".tmp")
 
   val mgr = new MigrationManager(cfg, file)

--- a/src/test/scala/org/fs/mael/core/speed/SpeedTrackerSpec.scala
+++ b/src/test/scala/org/fs/mael/core/speed/SpeedTrackerSpec.scala
@@ -11,6 +11,7 @@ import org.fs.mael.core.event.EventSubscriber
 import org.fs.mael.core.event.Events
 import org.fs.mael.core.event.Events._
 import org.fs.mael.test.stub.StoringEventManager
+import org.fs.mael.test.stub.StubBackend
 import org.joda.time.DateTimeUtils
 import org.junit.runner.RunWith
 import org.scalatest.FunSuite
@@ -156,7 +157,7 @@ class SpeedTrackerSpec
   }
 
   private def getEmptyDownloadEntry(): DownloadEntry =
-    DownloadEntry("", new URI(""), new File(""), None, None, "", new BackendConfigStore)
+    DownloadEntry("", new URI(""), new File(""), None, None, "", BackendConfigStore(StubBackend.SettingsAccessChecker))
 
   private def getNow() = System.currentTimeMillis
 

--- a/src/test/scala/org/fs/mael/core/speed/SpeedTrackerSpec.scala
+++ b/src/test/scala/org/fs/mael/core/speed/SpeedTrackerSpec.scala
@@ -5,7 +5,7 @@ import java.net.URI
 
 import scala.collection.immutable.SortedMap
 
-import org.fs.mael.core.config.InMemoryConfigStore
+import org.fs.mael.core.config.BackendConfigStore
 import org.fs.mael.core.entry.DownloadEntry
 import org.fs.mael.core.event.EventSubscriber
 import org.fs.mael.core.event.Events
@@ -156,7 +156,7 @@ class SpeedTrackerSpec
   }
 
   private def getEmptyDownloadEntry(): DownloadEntry =
-    DownloadEntry("", new URI(""), new File(""), None, None, "", new InMemoryConfigStore)
+    DownloadEntry("", new URI(""), new File(""), None, None, "", new BackendConfigStore)
 
   private def getNow() = System.currentTimeMillis
 

--- a/src/test/scala/org/fs/mael/test/TestUtils.scala
+++ b/src/test/scala/org/fs/mael/test/TestUtils.scala
@@ -1,7 +1,9 @@
 package org.fs.mael.test
 
+import org.fs.mael.core.config.BackendConfigStore
 import org.fs.mael.core.config.ConfigSetting
 import org.fs.mael.core.config.InMemoryConfigStore
+import org.fs.mael.core.config.SettingsAccessChecker
 import org.fs.mael.core.entry.DownloadEntry
 import org.scalatest.Assertions
 
@@ -25,12 +27,24 @@ object TestUtils extends Assertions {
     assert(de1.backendSpecificCfg === de2.backendSpecificCfg)
   }
 
-  implicit class RichMemoryConfigStore(val cfg: InMemoryConfigStore) {
+  val DummySettingsAccessChecker = new SettingsAccessChecker {
+    override val backendId = "<none!>"
+    override def isSettingIdAccessible(settingId: String): Boolean = true
+  }
+
+  implicit class RichBackendConfigStore(val cfg: BackendConfigStore) {
     def reset(): cfg.type = {
       cfg.resetTo(new InMemoryConfigStore)
       cfg
     }
 
+    def updated[T](setting: ConfigSetting[T], value: T): cfg.type = {
+      cfg.set(setting, value)
+      cfg
+    }
+  }
+
+  implicit class RichMemoryConfigStore(val cfg: InMemoryConfigStore) {
     def updated[T](setting: ConfigSetting[T], value: T): cfg.type = {
       cfg.set(setting, value)
       cfg

--- a/src/test/scala/org/fs/mael/test/TestUtils.scala
+++ b/src/test/scala/org/fs/mael/test/TestUtils.scala
@@ -25,13 +25,13 @@ object TestUtils extends Assertions {
     assert(de1.backendSpecificCfg === de2.backendSpecificCfg)
   }
 
-  implicit class RichMemoryConfigStore(cfg: InMemoryConfigStore) {
-    def reset(): InMemoryConfigStore = {
+  implicit class RichMemoryConfigStore(val cfg: InMemoryConfigStore) {
+    def reset(): cfg.type = {
       cfg.resetTo(new InMemoryConfigStore)
       cfg
     }
 
-    def updated[T](setting: ConfigSetting[T], value: T): InMemoryConfigStore = {
+    def updated[T](setting: ConfigSetting[T], value: T): cfg.type = {
       cfg.set(setting, value)
       cfg
     }

--- a/src/test/scala/org/fs/mael/test/stub/AbstractSimpleBackend.scala
+++ b/src/test/scala/org/fs/mael/test/stub/AbstractSimpleBackend.scala
@@ -5,6 +5,7 @@ import org.fs.mael.core.backend.AbstractBackend
 import org.fs.mael.core.backend.BackendDownloader
 import org.fs.mael.core.backend.ui.BackendConfigUi
 import org.fs.mael.core.config.BackendConfigStore
+import org.fs.mael.core.config.DefaultSettingsAccessChecker
 import org.fs.mael.core.config.IGlobalConfigStore
 import org.fs.mael.core.config.InMemoryConfigStore
 import org.fs.mael.core.entry.DownloadEntry
@@ -31,4 +32,6 @@ abstract class AbstractSimpleBackend(
   }
 
   override def pageDescriptors = Seq.empty
+
+  override val settingsAccessChecker = new DefaultSettingsAccessChecker(id)
 }

--- a/src/test/scala/org/fs/mael/test/stub/AbstractSimpleBackend.scala
+++ b/src/test/scala/org/fs/mael/test/stub/AbstractSimpleBackend.scala
@@ -4,13 +4,14 @@ import org.eclipse.swt.widgets.TabFolder
 import org.fs.mael.core.backend.AbstractBackend
 import org.fs.mael.core.backend.BackendDownloader
 import org.fs.mael.core.backend.ui.BackendConfigUi
-import org.fs.mael.core.config.ConfigStore
+import org.fs.mael.core.config.BackendConfigStore
+import org.fs.mael.core.config.IGlobalConfigStore
 import org.fs.mael.core.config.InMemoryConfigStore
 import org.fs.mael.core.entry.DownloadEntry
 
 abstract class AbstractSimpleBackend(
   override val id:        String,
-  override val globalCfg: ConfigStore = new InMemoryConfigStore
+  override val globalCfg: IGlobalConfigStore = new InMemoryConfigStore with IGlobalConfigStore
 ) extends AbstractBackend {
   override def init(): Unit = {}
 
@@ -25,8 +26,8 @@ abstract class AbstractSimpleBackend(
 
   def downloadStopped(de: DownloadEntry): Unit = {}
 
-  override def layoutConfig(cfgOption: Option[InMemoryConfigStore], tabFolder: TabFolder, isEditable: Boolean) = new BackendConfigUi {
-    override def get(): InMemoryConfigStore = cfgOption getOrElse defaultCfg
+  override def layoutConfig(cfgOption: Option[BackendConfigStore], tabFolder: TabFolder, isEditable: Boolean) = new BackendConfigUi {
+    override def get(): BackendConfigStore = cfgOption getOrElse defaultCfg
   }
 
   override def pageDescriptors = Seq.empty

--- a/src/test/scala/org/fs/mael/test/stub/StubBackend.scala
+++ b/src/test/scala/org/fs/mael/test/stub/StubBackend.scala
@@ -3,6 +3,7 @@ package org.fs.mael.test.stub
 import java.net.URI
 
 import org.fs.mael.core.config.ConfigSetting
+import org.fs.mael.core.config.DefaultSettingsAccessChecker
 
 class StubBackend
   extends AbstractSimpleBackend(
@@ -13,6 +14,8 @@ class StubBackend
 
 object StubBackend {
   val Id: String = "dummy"
+
+  val SettingsAccessChecker = new DefaultSettingsAccessChecker(Id)
 
   val StubSetting = ConfigSetting(Id + ".stubSetting", "defaultValue")
 }

--- a/tenor GIF.txt
+++ b/tenor GIF.txt
@@ -1,1 +1,0 @@
-https://media1.tenor.com/images/635c059475e08aa3c8334c2e5d86f638/tenor.gif

--- a/tenor GIF.txt
+++ b/tenor GIF.txt
@@ -1,0 +1,1 @@
+https://media1.tenor.com/images/635c059475e08aa3c8334c2e5d86f638/tenor.gif


### PR DESCRIPTION
Wraps `InMemoryConfigStore` inside `BackendConfigStore`, which checks that requested properties belong to that specific backend.
This would allow fail-fast behaviour for using mistakenly querying/changing settings out of backend scope